### PR TITLE
[4.0] Change access to body of Response object

### DIFF
--- a/src/AbstractMediawikiObject.php
+++ b/src/AbstractMediawikiObject.php
@@ -109,7 +109,7 @@ abstract class AbstractMediawikiObject
      */
     public function validateResponse(Response $response)
     {
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $xml = simplexml_load_string((string) $response->getBody());
 
         if (isset($xml->warnings)) {
             throw new \DomainException($xml->warnings->info);


### PR DESCRIPTION
### Summary of Changes
When converting the code to v4 of the Joomla HTTP package, the method `Response->getBody()->getContents()` was used to access the body of the response, which can be problematic, when the pointer of the internal stream is not set to the beginning. This PR changes the code to use the magic `__toString()` method of the `StreamInterface` instead.

### Testing Instructions
Codereview

### Documentation Changes Required
none